### PR TITLE
Skateboard api - updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.npz
 *.dae
 *.glb
+*.gltf
 aws/*
 data/*
 logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.npy
 *.npz
 *.dae
+*.glb
 aws/*
 data/*
 logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ tmp/*
 .DS_Store
 .vscode
 */logs/*
+*checkpoint_*
+events.out.tfevents*
 
 # Byte-compiled / optimized / DLL files
 **/__pycache__/*

--- a/snerg/requirements.txt
+++ b/snerg/requirements.txt
@@ -9,3 +9,8 @@ scipy>=1.4.1
 tensorboard>=2.4.0
 tensorflow>=2.3.1
 tensorflow-hub>=0.11.0
+
+# When running on AWS EC2 GPU instance, with a DLAMI that has CUDA 11:
+# flax==0.4.0
+# jax==0.3.1
+# jaxlib==0.1.74+cuda11.cudnn82

--- a/snerg/viewer/index.html
+++ b/snerg/viewer/index.html
@@ -170,6 +170,7 @@ body {
 <script src="https://unpkg.com/png-js@1.0.0/zlib.js"></script>
 <script src="https://unpkg.com/png-js@1.0.0/png.js"></script>
 <script src="https://unpkg.com/three@0.113.1/examples/js/loaders/GLTFLoader.js"></script>
+<script src="https://unpkg.com/three@0.113.1/examples/js/loaders/DRACOLoader.js"></script>
 <script src="indexFromGLB.js"></script>
 </body>
 </html>

--- a/snerg/viewer/index.html
+++ b/snerg/viewer/index.html
@@ -169,6 +169,7 @@ body {
 <script src="https://unpkg.com/three@0.113.1/examples/js/controls/OrbitControls.js"></script>
 <script src="https://unpkg.com/png-js@1.0.0/zlib.js"></script>
 <script src="https://unpkg.com/png-js@1.0.0/png.js"></script>
-<script src="indexFromMesh.js"></script>
+<script src="https://unpkg.com/three@0.113.1/examples/js/loaders/GLTFLoader.js"></script>
+<script src="indexFromGLB.js"></script>
 </body>
 </html>

--- a/snerg/viewer/indexFromGLB.js
+++ b/snerg/viewer/indexFromGLB.js
@@ -1009,9 +1009,12 @@ function loadScene(dirUrl, width, height) {
   // updateLoadingProgress();
 
   // Loads scene parameters (voxel grid size, NDC/no-NDC, view-dependence MLP).
-  let modelResourceUrl = dirUrl + '/' + 'lego.glb';
-  // Instantiate a loader
+  let modelResourceUrl = dirUrl + '/' + 'model.glb';
+  // Instantiate a loader, that utilizes Draco compression
   const loader = new THREE.GLTFLoader();
+  const dracoLoader = new THREE.DRACOLoader();
+    dracoLoader.setDecoderPath('https://unpkg.com/browse/three@0.113.1/examples/js/libs/draco/');
+  loader.setDRACOLoader( dracoLoader );
   // Load a glTF resource
   loader.load(
     // resource URL

--- a/snerg/viewer/indexFromGLB.js
+++ b/snerg/viewer/indexFromGLB.js
@@ -1021,17 +1021,13 @@ function loadScene(dirUrl, width, height) {
     modelResourceUrl,
     // called when the resource is loaded
     function ( gltf ) {
-      // TODO[debug]: this object is just a hack to make the code work like it used to for Meshes,
-        // otherwis it has no meaning
-      // gSceneParams = {};
-      // gSceneParams['dirUrl'] = dirUrl;
-      // gSceneParams['loadingTextures'] = false;
-      // gSceneParams['diffuse'] = true;
-      // add object to the scene + a camera
       gRayMarchScene = new THREE.Scene();
       gRayMarchScene.add( gltf.scene );
       // gRayMarchScene.autoUpdate = false;
-
+      // (6) add lights and camera
+      const light = new THREE.DirectionalLight(0xFFFFFF, 1);  // white light, intensity = 1
+        light.position.set(-1, 2, 4);
+        gRayMarchScene.add(light);
       gBlitCamera = new THREE.OrthographicCamera(
           width / -2, width / 2, height / 2, height / -2, -10000, 10000);
       gBlitCamera.position.z = 10;

--- a/snerg/viewer/indexFromGLB.js
+++ b/snerg/viewer/indexFromGLB.js
@@ -1009,12 +1009,12 @@ function loadScene(dirUrl, width, height) {
   // updateLoadingProgress();
 
   // Loads scene parameters (voxel grid size, NDC/no-NDC, view-dependence MLP).
-  let modelResourceUrl = dirUrl + '/' + 'model.glb';
+  let modelResourceUrl = dirUrl + '/' + 'engine.glb';
   // Instantiate a loader, that utilizes Draco compression
   const loader = new THREE.GLTFLoader();
-  const dracoLoader = new THREE.DRACOLoader();
-    dracoLoader.setDecoderPath('https://unpkg.com/browse/three@0.113.1/examples/js/libs/draco/');
-  loader.setDRACOLoader( dracoLoader );
+    const dracoLoader = new THREE.DRACOLoader();
+    dracoLoader.setDecoderPath('https://unpkg.com/three@0.113.1/examples/js/libs/draco/')
+    loader.setDRACOLoader( dracoLoader );
   // Load a glTF resource
   loader.load(
     // resource URL
@@ -1036,6 +1036,7 @@ function loadScene(dirUrl, width, height) {
           width / -2, width / 2, height / 2, height / -2, -10000, 10000);
       gBlitCamera.position.z = 10;
       requestAnimationFrame(render);
+      console.log("Model has been loaded!")
     },
     // called while loading is progressing
     function ( xhr ) {},


### PR DESCRIPTION
- This gives us two versions `index.js` - 1 for loading SNeRG straight from the texture atlas assets, and one from a pre-compiled GLB
- updates `requirements.txt` for when we're on an EC2 instance with the Deep Learning AMI
- updates `.gitignore` to include GLB/glTF, and artifacts of TensorFlow training, i.e. checkpoint files and event files